### PR TITLE
feat: add smart harvest capabilities

### DIFF
--- a/paper-survival/build.gradle.kts
+++ b/paper-survival/build.gradle.kts
@@ -1,15 +1,34 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.shadow)
 }
 
 dependencies {
     implementation(project(":common"))
-    compileOnly(project(":paper-base"))
+    compileOnly(project(":paper-base", configuration = "shadow"))
 
     compileOnly("io.papermc.paper:paper-api:1.21.9-R0.1-SNAPSHOT")
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
 tasks {
+    compileJava {
+        options.encoding = "UTF-8"
+        options.release.set(21)
+    }
+
+    compileKotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_21
+        }
+    }
+
     shadowJar {
         archiveClassifier.set("")
         mergeServiceFiles()

--- a/paper-survival/src/main/java/io/d2a/ara/paper/survival/AragokPaperSurvivalBootstrap.java
+++ b/paper-survival/src/main/java/io/d2a/ara/paper/survival/AragokPaperSurvivalBootstrap.java
@@ -1,0 +1,58 @@
+package io.d2a.ara.paper.survival;
+
+import io.papermc.paper.plugin.bootstrap.BootstrapContext;
+import io.papermc.paper.plugin.bootstrap.PluginBootstrap;
+import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.TypedKey;
+import io.papermc.paper.registry.data.EnchantmentRegistryEntry;
+import io.papermc.paper.registry.event.RegistryEvents;
+import io.papermc.paper.registry.keys.tags.EnchantmentTagKeys;
+import io.papermc.paper.registry.keys.tags.ItemTypeTagKeys;
+import io.papermc.paper.tag.PostFlattenTagRegistrar;
+import net.kyori.adventure.text.Component;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.EquipmentSlotGroup;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+@SuppressWarnings("UnstableApiUsage")
+public class AragokPaperSurvivalBootstrap implements PluginBootstrap {
+
+    @Override
+    public void bootstrap(@NotNull final BootstrapContext context) {
+        context.getLogger().info("Bootstrapping Aragok");
+
+        final var GREEN_THUMB = TypedKey.create(RegistryKey.ENCHANTMENT, Constants.GREEN_THUMB);
+
+        context.getLogger().info("Registering Green Thumb Enchantment with key: {}", GREEN_THUMB);
+        context.getLifecycleManager().registerEventHandler(RegistryEvents.ENCHANTMENT
+                .compose()
+                .newHandler(event -> event
+                        .registry()
+                        .register(
+                                GREEN_THUMB,
+                                builder -> builder
+                                        .description(Component.translatable(Constants.GREEN_THUMB_ENCHANTMENT_KEY, "Green Thumb"))
+                                        .supportedItems(event.getOrCreateTag(ItemTypeTagKeys.ENCHANTABLE_MINING))
+                                        .weight(5)
+                                        .maxLevel(1)
+                                        .minimumCost(EnchantmentRegistryEntry.EnchantmentCost.of(1, 0))
+                                        .maximumCost(EnchantmentRegistryEntry.EnchantmentCost.of(50, 0))
+                                        .anvilCost(2)
+                                        .activeSlots(EquipmentSlotGroup.HAND)
+                        )));
+
+        context.getLogger().info("Registering Green Thumb Enchantment to relevant tags");
+        context.getLifecycleManager().registerEventHandler(LifecycleEvents.TAGS
+                        .postFlatten(RegistryKey.ENCHANTMENT),
+                event -> {
+                    final PostFlattenTagRegistrar<Enchantment> registrar = event.registrar();
+                    registrar.addToTag(EnchantmentTagKeys.TRADEABLE, Set.of(GREEN_THUMB));
+                    registrar.addToTag(EnchantmentTagKeys.NON_TREASURE, Set.of(GREEN_THUMB));
+                    registrar.addToTag(EnchantmentTagKeys.IN_ENCHANTING_TABLE, Set.of(GREEN_THUMB));
+                });
+    }
+
+}

--- a/paper-survival/src/main/java/io/d2a/ara/paper/survival/Constants.java
+++ b/paper-survival/src/main/java/io/d2a/ara/paper/survival/Constants.java
@@ -1,0 +1,12 @@
+package io.d2a.ara.paper.survival;
+
+import net.kyori.adventure.key.Key;
+
+public class Constants {
+
+    public static final String GREEN_THUMB_KEY = "aragok:green-thumb";
+    public static final String GREEN_THUMB_ENCHANTMENT_KEY = "enchantment.green-thumb";
+
+    public static final Key GREEN_THUMB = Key.key(GREEN_THUMB_KEY);
+
+}

--- a/paper-survival/src/main/kotlin/io/d2a/ara/paper/survival/AragokPaperSurvival.kt
+++ b/paper-survival/src/main/kotlin/io/d2a/ara/paper/survival/AragokPaperSurvival.kt
@@ -49,7 +49,6 @@ class AragokPaperSurvival : JavaPlugin() {
     // ender storage
     val enderStorageRecipeKey = NamespacedKey(this, "ender_storage")
 
-
     override fun onEnable() {
         EnderStorageKeys.init(this)
 

--- a/paper-survival/src/main/kotlin/io/d2a/ara/paper/survival/AragokPaperSurvival.kt
+++ b/paper-survival/src/main/kotlin/io/d2a/ara/paper/survival/AragokPaperSurvival.kt
@@ -17,6 +17,7 @@ import io.d2a.ara.paper.survival.floo.FlooItem.Companion.toEssenceItem
 import io.d2a.ara.paper.survival.floo.FlooItem.Companion.toUnusedPowderItem
 import io.d2a.ara.paper.survival.floo.FlooUseListeners
 import io.d2a.ara.paper.survival.floo.WitchDropEssenceListener
+import io.d2a.ara.paper.survival.harvest.SmartHarvestListener
 import io.d2a.ara.paper.survival.hopper.*
 import io.d2a.ara.paper.survival.restriction.DimensionRestriction
 import io.d2a.ara.paper.survival.sleep.EnterBedSleepListener
@@ -83,6 +84,7 @@ class AragokPaperSurvival : JavaPlugin() {
         registerFlooFeature()
         registerHopperFeature()
         registerEndStorageFeature()
+        registerHarvestFeature()
 
         logger.info("Enabled aragok-survival")
     }
@@ -271,6 +273,14 @@ class AragokPaperSurvival : JavaPlugin() {
         registerEvents(
             EnderStoragePlaceBreakListener(logger),
             EnderStorageUseListener(logger, storage)
+        )
+    }
+
+    fun registerHarvestFeature() {
+        logger.info("Registering smart harvest feature...")
+
+        registerEvents(
+            SmartHarvestListener(logger)
         )
     }
 

--- a/paper-survival/src/main/kotlin/io/d2a/ara/paper/survival/harvest/SmartHarvestListener.kt
+++ b/paper-survival/src/main/kotlin/io/d2a/ara/paper/survival/harvest/SmartHarvestListener.kt
@@ -1,0 +1,88 @@
+package io.d2a.ara.paper.survival.harvest
+
+import org.bukkit.Material
+import org.bukkit.block.Block
+import org.bukkit.block.data.Ageable
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack
+import java.util.logging.Logger
+
+class SmartHarvestListener(
+    val logger: Logger,
+) : Listener {
+
+    private val harvestableBlocks = setOf(
+        Material.WHEAT,
+        Material.CARROT,
+        Material.POTATO,
+        Material.BEETROOTS,
+        Material.NETHER_WART,
+    )
+
+    @EventHandler
+    fun onPlayerInteract(event: PlayerInteractEvent) {
+        val player = event.player
+        val hand = event.hand ?: return
+        if (hand != EquipmentSlot.OFF_HAND) { // only on off hand
+            return
+        }
+        logger.info { "OFF Hand was used" }
+
+        val block = event.clickedBlock ?: return
+        val type = block.type
+        val data = block.blockData
+        logger.info("Clicked Block ${block.type}")
+        if (block.type !in harvestableBlocks) {
+            return
+        }
+
+        // Check if block is fully grown
+        if (!isHarvestable(block)) {
+            return
+        }
+        logger.info("Block is ready to harvest")
+
+        event.isCancelled = true // Prevent default interaction
+        block.breakNaturally()
+
+        // Check if player has same Material in inventory
+        val seed = getSeedTypeFromCrop(type) ?: return
+        val hasItemInInventory = player.inventory.contains(seed)
+        logger.info { "Has item in inventory? => $hasItemInInventory" }
+        if (!hasItemInInventory) {
+            return
+        }
+
+        // Remove one item from inventory
+        player.inventory.removeItem(ItemStack(seed, 1))
+
+        // Replant the crop
+        block.type = type
+        if (data is Ageable) {
+            data.age = 0
+        }
+        block.blockData = data
+    }
+
+    fun getSeedTypeFromCrop(crop: Material): Material? {
+        return when (crop) {
+            Material.WHEAT -> Material.WHEAT_SEEDS
+            Material.CARROT -> Material.CARROT
+            Material.POTATO -> Material.POTATO
+            Material.BEETROOTS -> Material.BEETROOT_SEEDS
+            Material.NETHER_WART -> Material.NETHER_WART
+            else -> null
+        }
+    }
+
+    fun isHarvestable(block: Block): Boolean {
+        val data = block.blockData
+        return when {
+            data is Ageable && data.age == data.maximumAge -> true
+            else -> false
+        }
+    }
+}

--- a/paper-survival/src/main/resources/paper-plugin.yml
+++ b/paper-survival/src/main/resources/paper-plugin.yml
@@ -1,6 +1,9 @@
 name: aragok-paper-survival
 version: '${version}'
+
 main: io.d2a.ara.paper.survival.AragokPaperSurvival
+bootstrapper: io.d2a.ara.paper.survival.AragokPaperSurvivalBootstrap
+
 api-version: '1.21'
 
 dependencies:


### PR DESCRIPTION
This pull request adds the smart harvest feature. If a simple crop such as wheat, carrots or potatoes is fully grown. Right clicking on it will break it and immediately replace it with a seed of the crop, if the player has one in their inventory.
If the crop is not fully matured, right clicking will do nothing.